### PR TITLE
Fix bugs in fraction bars

### DIFF
--- a/js/Bar.js
+++ b/js/Bar.js
@@ -489,6 +489,9 @@ export default class Bar {
     }
 
     static createFromMouse(p1, p2, type, color) {
+        if (!p1 || !p2) {
+            return null;
+        }
         const w = Math.abs(p2.x - p1.x);
         const h = Math.abs(p2.y - p1.y);
         const p = Point.min(p1, p2);

--- a/js/CanvasState.js
+++ b/js/CanvasState.js
@@ -35,4 +35,14 @@ export default class CanvasState {
         }
         this.mHidden = [...fractionBarsCanvas.hiddenButtonsName];
     }
+
+    cacheUndoState(fractionBarsCanvas) {
+        this.grabBarsAndMats(fractionBarsCanvas);
+    }
+
+    finalizeCachedUndoState(fractionBarsCanvas) {
+        const newState = new CanvasState();
+        newState.grabBarsAndMats(fractionBarsCanvas);
+        fractionBarsCanvas.mUndoArray.push(newState);
+    }
 }

--- a/js/fractionBars.js
+++ b/js/fractionBars.js
@@ -458,7 +458,7 @@ function handleClick(e) {
 
 function handleMouseDown(e) {
     fbCanvasObj.check_for_drag = true;
-    fbCanvasObj.cacheUndoState();
+    fbCanvasObj.canvasState.cacheUndoState(fbCanvasObj);
 
     updateMouseLoc(e, this);
     updateMouseAction('mousedown');
@@ -517,7 +517,7 @@ function handleMouseUp(e) {
     }
 
     if (fbCanvasObj.found_a_drag) {
-        fbCanvasObj.finalizeCachedUndoState();
+        fbCanvasObj.canvasState.finalizeCachedUndoState(fbCanvasObj);
         fbCanvasObj.check_for_drag = false;
     }
 


### PR DESCRIPTION
Fix various TypeErrors in `fractionBars.js` and `Bar.js`.

* **CanvasState.js**
  - Add `cacheUndoState` method to cache the current state of the canvas.
  - Add `finalizeCachedUndoState` method to finalize the cached undo state.

* **fractionBars.js**
  - Replace `fbCanvasObj.cacheUndoState` with `fbCanvasObj.canvasState.cacheUndoState` in `handleMouseDown` function.
  - Replace `fbCanvasObj.finalizeCachedUndoState` with `fbCanvasObj.canvasState.finalizeCachedUndoState` in `handleMouseUp` function.

* **Bar.js**
  - Add null check for `p1` and `p2` in `createFromMouse` method to prevent `Uncaught TypeError`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TioSavich/Fraction_Bars/pull/1?shareId=1fb0d926-9644-4f14-afe4-79cdf45c580d).